### PR TITLE
Replace matplotlib with much faster OpenCV 3.2 in the show_frame func…

### DIFF
--- a/src/visualization.py
+++ b/src/visualization.py
@@ -1,18 +1,17 @@
 import numpy as np
 import matplotlib.patches as patches
 import matplotlib.pyplot as plt
+import cv2
 
 
 def show_frame(frame, bbox, fig_n):
-    fig = plt.figure(fig_n)
-    ax = fig.add_subplot(111)
-    r = patches.Rectangle((bbox[0],bbox[1]), bbox[2], bbox[3], linewidth=2, edgecolor='r', fill=False)
-    ax.imshow(np.uint8(frame))
-    ax.add_patch(r)
-    plt.ion()
-    plt.show()
-    plt.pause(0.001)
-    plt.clf()
+    #Adjust Color Channels of frame
+    frame_adjusted = np.ndarray(shape=(720,1280,3), dtype=np.dtype(np.uint8))
+    frame_adjusted[:,:,:] = frame[:,:,2::-1]
+    x, y, w, h = int(bbox[0]), int(bbox[1]), int(bbox[2]), int(bbox[3])
+    cv2.rectangle(frame_adjusted, (x, y), (x+w,y+h), (0,0,255), 4, 8, 0)
+    cv2.imshow('image',frame_adjusted)
+    cv2.waitKey(1)
 
 
 def show_crops(crops, fig_n):


### PR DESCRIPTION
 …tion.

Fixes Issue #4

I went from ~6fps to ~30fps on my machine.

This still requires changes to the "requirements.txt" file and a python module with OpenCV compiled to use imshow and waitKey must be required (currently the popular but unofficial opencv-python module does not implement them).

Since show_frame no longer uses matplotlib and show_crops and show_scores don't look like they're used at all (didn't check everywhere) it looks like the requirement for matplotlib could be removed along with the references to it in visualization.py and tracker.py (in the imports in that file, and on line 135).