### PR TITLE
Fix reading validation dataset

### DIFF
--- a/run_tracker_evaluation.py
+++ b/run_tracker_evaluation.py
@@ -26,7 +26,7 @@ def main():
     # iterate through all videos of evaluation.dataset
     if evaluation.video == 'all':
         dataset_folder = os.path.join(env.root_dataset, evaluation.dataset)
-        videos_list = [v for v in os.listdir(dataset_folder)]
+        videos_list = [v for v in os.listdir(dataset_folder) if os.path.isdir(os.path.join(dataset_folder, v))]
         videos_list.sort()
         nv = np.size(videos_list)
         speed = np.zeros(nv * evaluation.n_subseq)


### PR DESCRIPTION
Reading the data set assumed that there were no files in the `./data/validation folder`. It doesn't behave well when a file is present. For example, `README.txt` in the ZIP provided as the [validation sequences](https://drive.google.com/file/d/0B7Awq_aAemXQSnhBVW5LNmNvUU0/view) would be read as a video sequence (directory). This update fixes this problem.